### PR TITLE
feat: additional approval on Version change

### DIFF
--- a/.github/workflows/approve-version-bump.yml
+++ b/.github/workflows/approve-version-bump.yml
@@ -1,0 +1,98 @@
+name: Approve Version Bump
+
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  check_reaction:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Find the warning comment by the bot
+        id: find_comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const comments = await github.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            // Find the warning comment made by the bot
+            const warningComment = comments.data.find(comment =>
+              comment.user.login === 'github-actions[bot]' && comment.body.includes('Warning: This PR will result in a new release')
+            );
+
+            if (warningComment) {
+              return { comment_id: warningComment.id };
+            } else {
+              throw new Error('Warning comment not found.');
+            }
+
+      - name: Check if the comment has a thumbs up reaction
+        id: check_reaction
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const reactions = await github.reactions.listForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: ${{ steps.find_comment.outputs.comment_id }},
+            });
+
+            const thumbsUp = reactions.data.find(reaction => reaction.content === '+1');
+            return { thumbs_up: thumbsUp ? 'true' : 'false' };
+
+      - name: Extract maintainers from CODEOWNERS
+        id: get_codeowners
+        run: |
+          # Extract the maintainers from CODEOWNERS file
+          maintainers=$(grep -v '^#' CODEOWNERS | awk '{print $NF}' | sort | uniq)
+          echo "maintainers=$maintainers" >> $GITHUB_ENV
+
+      - name: Check if the reaction is from a maintainer
+        if: steps.check_reaction.outputs.thumbs_up == 'true'
+        id: check_maintainer
+        run: |
+          # Get the login of the person who added the thumbs-up reaction
+          reaction_author="${{ github.event.comment.user.login }}"
+          maintainers="${{ env.maintainers }}"
+
+          # Convert maintainers string to array
+          IFS=' ' read -r -a maintainers_array <<< "$maintainers"
+
+          # Check if the reaction author is in the list of maintainers
+          if [[ " ${maintainers_array[@]} " =~ " $reaction_author " ]]; then
+            echo "Approval granted by maintainer: $reaction_author"
+            echo "is_approved=true" >> $GITHUB_ENV
+          else
+            echo "Approval not granted by a maintainer"
+            echo "is_approved=false" >> $GITHUB_ENV
+
+      - name: Unblock PR if approved
+        if: env.is_approved == 'true'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pr_number = context.payload.issue.number;
+            await github.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: "success", # Mark the check as successful
+              context: "version-bump-check",
+              description: "Approved by maintainer",
+            });
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -1,0 +1,88 @@
+name: Check for Version Bump in Chart.yaml
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - deployments/chart/Chart.yaml
+
+jobs:
+  check_version_bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            deployments/chart/Chart.yaml
+
+      - name: Check if Chart.yaml has changed
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: echo "Chart.yaml has been modified."
+
+      - name: Extract version from Chart.yaml
+        id: chart_version
+        run: |
+          version=$(yq e '.version' ./deployments/chart/Chart.yaml)
+          echo "version=$version" >> $GITHUB_ENV
+          echo "Current Chart version: $version"
+        
+      - name: Get latest Git tag
+        id: get_latest_tag
+        run: |
+          latest_tag=$(git describe --tags --abbrev=0 || echo "0.0.0")
+          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
+          echo "Latest Git tag: $latest_tag"
+
+      - name: Compare versions
+        id: compare_versions
+        run: |
+          chart_version=${{ env.version }}
+          git_tag_version=${{ env.latest_tag }}
+          
+          # Strip any leading 'v' from the Git tag to compare versions numerically
+          git_tag_version="${git_tag_version#v}"
+
+          if [ "$chart_version" != "$git_tag_version" ]; then
+            echo "Version bump detected: Chart version ($chart_version) differs from latest Git tag ($git_tag_version)"
+            echo "version_bump=true" >> $GITHUB_ENV
+          else
+            echo "No version bump detected."
+            echo "version_bump=false" >> $GITHUB_ENV
+
+      - name: Post warning comment
+        if: env.version_bump == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: "Warning: This PR will result in a new release because the version in Chart.yaml (`${{ env.version }}`) is different from the latest Git tag (`${{ env.latest_tag }}`). Please confirm before merging."
+
+      - name: Set PR as blocked (requires thumbs up from maintainer)
+        if: env.version_bump == 'true'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+            await github.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: sha,
+              state: 'failure',
+              context: 'version-bump-check',
+              description: 'Version bump detected. Awaiting maintainer approval.',
+            });
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        


### PR DESCRIPTION
## Motivation

This change aims to improve the workflow process by allowing a version bump to be properly reviewed and approved by maintainers using GitHub reactions. It enhances the PR approval flow by ensuring no accidental releases are triggered without explicit maintainer approval.

## Changes

- Added a workflow to block PRs with version bumps in `Chart.yaml`.
- Added a second workflow to unblock PRs when maintainers give a thumbs-up reaction on the warning comment.
- Integrated `CODEOWNERS` to ensure approval is only given by maintainers.

## Tests done

- Tested version bump detection in `Chart.yaml`.
- Verified PR blocking on version bump.
- Tested unblocking of PR on maintainer approval through the thumbs-up emoji.

## TODO

- [x] I've assigned myself to this PR